### PR TITLE
Feature/oee summary stats

### DIFF
--- a/data-prep/summary_statistics/project_data_summary_oee.csv
+++ b/data-prep/summary_statistics/project_data_summary_oee.csv
@@ -1,0 +1,29 @@
+Summary Stat,Value
+Total number of records,3877
+Number of unique project electric SAIDs,3480
+Top 10 zip codes by count,"95687,95688,93711,94533,93635,95616,94530,94611,94534,95209"
+Bottom 10 zip codes by count,"93245,93292,93301,93420,93436,93444,93453,93610,93618,93625"
+Min Work Start Date,2012-08-20
+Max Work Start Date,2016-06-08
+Average Work Start Date,2015-01-12
+Work Start Date 10th percentile value,2014-01-16
+Work Start Date 20th percentile value,2014-04-09
+Work Start Date 30th percentile value,2014-06-27
+Work Start Date 40th percentile value,2014-10-03
+Work Start Date 50th percentile value,2015-01-12
+Work Start Date 60th percentile value,2015-04-13
+Work Start Date 70th percentile value,2015-07-22
+Work Start Date 80th percentile value,2015-11-05
+Work Start Date 90th percentile value,2016-01-25
+Min Work Finish Date,2012-12-03
+Max Work Finish Date,2016-06-13
+Average Work Finish Date,2015-02-24
+Work Finish Date 10th percentile value,2014-03-07
+Work Finish Date 20th percentile value,2014-06-02
+Work Finish Date 30th percentile value,2014-08-21
+Work Finish Date 40th percentile value,2014-11-06
+Work Finish Date 50th percentile value,2015-02-11
+Work Finish Date 60th percentile value,2015-05-19
+Work Finish Date 70th percentile value,2015-09-03
+Work Finish Date 80th percentile value,2015-12-08
+Work Finish Date 90th percentile value,2016-02-29


### PR DESCRIPTION
First crack at these.

They have slight disagreement with Energy Savvy's push.

Basic process:
- Concatenate all project files
- Apply Work Date rules to fill in missing dates (all rows get a date)
- Filter out any projects that don't match an `sa_id` in `Electric Service ID` or `Gas Service ID` in xref files
- Then compute all the summary stats
